### PR TITLE
chore: adopt reusable release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,48 +1,17 @@
 name: release
 
 on:
-  release:
-    types: [published]
+  create:
+    tags:
 
 jobs:
-  pypi:
-    name: Publish to PyPI registry
+  before-release:
+    uses: ansible-community/ansible-compat/.github/workflows/tox.yml@main
+
+  release:
     environment: release
-    runs-on: ubuntu-20.04
-
-    env:
-      FORCE_COLOR: 1
-      PY_COLORS: 1
-      TOXENV: packaging
-      TOX_PARALLEL_NO_SPINNER: 1
-
-    steps:
-    - name: Switch to using Python 3.8 by default
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Install tox
-      run: >-
-        python3 -m
-        pip install
-        --user
-        tox
-    - name: Check out src from Git
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0  # needed by setuptools-scm
-    - name: Build dists
-      run: python -m tox
-    - name: Publish to test.pypi.org
-      if: >-
-        github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.testpypi_password }}
-        repository_url: https://test.pypi.org/legacy/
-    - name: Publish to pypi.org
-      if: >-
-        github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.pypi_password }}
+    name: release ${{ github.event.ref }}
+    needs: before-release
+    uses: ansible-community/devtools/.github/workflows/release.yml@main
+    with:
+      pypi: true


### PR DESCRIPTION
This new workflow should allow us to control the release to pypi from a single location.
