### PR TITLE
chore: remove unaccepted keyword for reused workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ jobs:
     uses: ansible-community/ansible-compat/.github/workflows/tox.yml@main
 
   release:
-    environment: release
     name: release ${{ github.event.ref }}
     needs: before-release
     uses: ansible-community/devtools/.github/workflows/release.yml@main


### PR DESCRIPTION
Based on docs, when using `uses:`, we can only use a limited set
of keywords.

See: https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow