### PR TITLE
Bump test deps

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,11 @@ alabaster==0.7.12
     # via sphinx
 ansible-pygments==0.1.1
     # via sphinx-ansible-theme
-argh==0.26.2
-    # via sphinx-autobuild
 attrs==22.1.0
     # via
     #   jsonschema
     #   pytest
-babel==2.10.3
+babel==2.11.0
     # via sphinx
 build==0.9.0
     # via pip-tools
@@ -24,8 +22,8 @@ charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via pip-tools
-commonmark==0.9.1
-    # via pytest-markdown
+colorama==0.4.6
+    # via sphinx-autobuild
 coverage==6.5.0
     # via ansible-compat (setup.cfg)
 docutils==0.17.1
@@ -33,6 +31,8 @@ docutils==0.17.1
     #   myst-parser
     #   sphinx
     #   sphinx-rtd-theme
+exceptiongroup==1.0.0
+    # via pytest
 flaky==3.7.0
     # via ansible-compat (setup.cfg)
 idna==3.4
@@ -71,17 +71,11 @@ packaging==21.3
     #   build
     #   pytest
     #   sphinx
-pathtools==0.1.2
-    # via sphinx-autobuild
 pep517==0.13.0
     # via build
 pip-tools==6.9.0
     # via ansible-compat (setup.cfg)
 pluggy==1.0.0
-    # via pytest
-port-for==0.3.1
-    # via sphinx-autobuild
-py==1.11.0
     # via pytest
 pygments==2.13.0
     # via
@@ -91,40 +85,37 @@ pyparsing==3.0.9
     # via packaging
 pyrsistent==0.19.1
     # via jsonschema
-pytest==6.2.5
+pytest==7.2.0
     # via
     #   ansible-compat (setup.cfg)
-    #   pytest-markdown
     #   pytest-mock
     #   pytest-plus
-pytest-markdown==1.0.2
-    # via ansible-compat (setup.cfg)
 pytest-mock==3.10.0
     # via ansible-compat (setup.cfg)
 pytest-plus==0.2
     # via ansible-compat (setup.cfg)
-pytz==2022.5
+pytz==2022.6
     # via babel
 pyyaml==6.0
     # via
     #   ansible-compat (setup.cfg)
     #   myst-parser
-    #   sphinx-autobuild
 requests==2.28.1
     # via sphinx
 six==1.16.0
     # via livereload
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.5.0
+sphinx==5.3.0
     # via
     #   ansible-compat (setup.cfg)
     #   myst-parser
     #   sphinx-ansible-theme
+    #   sphinx-autobuild
     #   sphinx-rtd-theme
 sphinx-ansible-theme==0.9.1
     # via ansible-compat (setup.cfg)
-sphinx-autobuild==0.7.1
+sphinx-autobuild==2021.3.14
     # via ansible-compat (setup.cfg)
 sphinx-rtd-theme==1.0.0
     # via sphinx-ansible-theme
@@ -142,22 +133,17 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 subprocess-tee==0.3.5
     # via ansible-compat (setup.cfg)
-toml==0.10.2
-    # via pytest
 tomli==2.0.1
     # via
     #   build
     #   pep517
+    #   pytest
 tornado==6.2
-    # via
-    #   livereload
-    #   sphinx-autobuild
+    # via livereload
 typing-extensions==4.4.0
     # via myst-parser
 urllib3==1.26.12
     # via requests
-watchdog==2.1.9
-    # via sphinx-autobuild
 wheel==0.37.1
     # via pip-tools
 zipp==3.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,16 +64,15 @@ install_requires =
 
 [options.extras_require]
 docs =
-  sphinx-autobuild>=0.7.1,<1.0
-  sphinx>=4.2.0,<5.0
+  sphinx-autobuild>=2021.3.14
+  sphinx>=5.3.0
   sphinx_ansible_theme
   myst_parser
 test =
   coverage
   flaky
   pip-tools
-  pytest
-  pytest-markdown
+  pytest>=7.2.0
   pytest-mock
   pytest-plus
 


### PR DESCRIPTION
We also drop pytest-markdown due to lack of maintenance.

Related: https://github.com/Jc2k/pytest-markdown/issues/10