### PR TITLE
Update build-system dependency for setuptools-scm to >= 7.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [build-system]
 requires = [
   "setuptools >= 45.0.0", # required by pyproject+setuptools_scm integration
-  "setuptools_scm >= 6.3.1", # required for "no-local-version" scheme
-  "setuptools_scm_git_archive >= 1.0",
-  "wheel",
+  "setuptools_scm[toml] >= 7.0.0", # required for "no-local-version" scheme
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
   "setuptools >= 45.0.0", # required by pyproject+setuptools_scm integration
   "setuptools_scm[toml] >= 7.0.0", # required for "no-local-version" scheme
+
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
pyproject.toml:
Update build-system dependency for setuptools-scm to >= 7.0.0, which obsoletes setuptools-scm-git-archive.
Remove wheel as it is not required in a PEP517 build environment facilitating pypa/build and pypa/installer.