### PR TITLE
Revert "Avoid running galaxy on offline mode (#180)"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,14 +85,13 @@ repos:
         additional_dependencies:
           - cached_property
           - flaky
-          - jinja2
           - packaging
           - pytest
           - pytest-mock
           - subprocess-tee>=0.3.5
           - types-PyYAML
-          - types-jsonschema>=4.4.9
           - types-pkg_resources
+          - types-jsonschema>=4.4.9
   - repo: https://github.com/pycqa/pylint
     rev: v2.15.5
     hooks:

--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -270,7 +270,6 @@ class Runtime:
                     force=True,
                 )
 
-    # pylint: disable=too-many-branches
     def install_requirements(
         self, requirement: str, retry: bool = False, offline: bool = False
     ) -> None:
@@ -296,14 +295,13 @@ class Runtime:
 
             if offline:
                 _logger.warning(
-                    "Role installation skipped because `ansible-galaxy role install` command does not support an offline mode."
+                    "Offline mode ignored because `ansible-galaxy role install` command does not support it."
                 )
-            else:
-                _logger.info("Running %s", " ".join(cmd))
-                result = self.exec(cmd, retry=retry)
-                if result.returncode != 0:
-                    _logger.error(result.stdout)
-                    raise AnsibleCommandError(result)
+            _logger.info("Running %s", " ".join(cmd))
+            result = self.exec(cmd, retry=retry)
+            if result.returncode != 0:
+                _logger.error(result.stdout)
+                raise AnsibleCommandError(result)
 
         # Run galaxy collection install works on v2 requirements.yml
         if "collections" in reqs_yaml:
@@ -314,25 +312,22 @@ class Runtime:
                 "install",
                 "-v",
             ]
-            skip = False
             if offline:
                 if self.version_in_range(upper="2.14"):
                     _logger.warning(
-                        "Collection install skipped because ansible versions before 2.14 do not support an offline mode."
+                        "Offline mode ignored because it is not supported by ansible versions before 2.14."
                     )
-                    skip = True
                 else:
                     cmd.append("--offline")
-            if not skip:
-                cmd.extend(["-r", requirement])
-                if self.cache_dir:
-                    cmd.extend(["-p", f"{self.cache_dir}/collections"])
-                _logger.info("Running %s", " ".join(cmd))
-                result = self.exec(cmd, retry=retry)
-                if result.returncode != 0:
-                    _logger.error(result.stdout)
-                    _logger.error(result.stderr)
-                    raise AnsibleCommandError(result)
+            cmd.extend(["-r", requirement])
+            if self.cache_dir:
+                cmd.extend(["-p", f"{self.cache_dir}/collections"])
+            _logger.info("Running %s", " ".join(cmd))
+            result = self.exec(cmd, retry=retry)
+            if result.returncode != 0:
+                _logger.error(result.stdout)
+                _logger.error(result.stderr)
+                raise AnsibleCommandError(result)
 
     def prepare_environment(  # noqa: C901
         self,

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -662,14 +662,7 @@ def test_prepare_environment_offline_role() -> None:
     """Ensure that we can make use of offline roles."""
     with remember_cwd("test/roles/acme.missing_deps"):
         runtime = Runtime(isolated=True)
-        if runtime.version_in_range(lower="2.14"):
-            # starting with 2.14 we can properly fail because this role has
-            # some missing collections in its requirements. We pass the offline
-            # but install will fail because there are not really offline
-            # requirements.
-            with pytest.raises(AnsibleCommandError):
-                runtime.prepare_environment(install_local=True, offline=True)
-        else:
+        with pytest.raises(AnsibleCommandError):
             runtime.prepare_environment(install_local=True, offline=True)
 
 


### PR DESCRIPTION
This reverts commit 58a50370726bb05469f17ee745403b070e57b53e.

As ansible-galaxy new `--offline` option does not have any practical use for people using requirement files, it means that compat should not have special treatment for it.

Related: https://github.com/ansible/ansible-lint/issues/2729
Related: https://github.com/ansible/ansible-lint/issues/2651
Related: https://github.com/ansible/ansible-lint/issues/2683
