### PR TITLE
Restore offline more functionality

### DIFF
--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -662,8 +662,7 @@ def test_prepare_environment_offline_role() -> None:
     """Ensure that we can make use of offline roles."""
     with remember_cwd("test/roles/acme.missing_deps"):
         runtime = Runtime(isolated=True)
-        with pytest.raises(AnsibleCommandError):
-            runtime.prepare_environment(install_local=True, offline=True)
+        runtime.prepare_environment(install_local=True, offline=True)
 
 
 def test_runtime_run(runtime: Runtime) -> None:


### PR DESCRIPTION
We bring back old behavior of offline more as the new one did not work as intended and was not full offline either.

Related: https://github.com/ansible/ansible-lint/issues/2796