### PR TITLE
src/ansible_compat/runtime.py: Fix collection loading

### DIFF
--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -144,9 +144,9 @@ class Runtime:
                 # noinspection PyProtectedMember
                 # pylint: disable=protected-access
                 col_path += self.config.collections_paths
-                col_path += [
-                    os.path.dirname(os.environ.get(ansible_collections_path(), "."))
-                ]
+                col_path += os.path.dirname(
+                    os.environ.get(ansible_collections_path(), ".")
+                ).split(":")
                 _AnsibleCollectionFinder(
                     paths=col_path
                 )._install()  # pylint: disable=protected-access

--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -129,11 +129,12 @@ class Runtime:
         # For ansible 2.15+ we need to initialize the plugin loader
         # https://github.com/ansible/ansible-lint/issues/2945
         if not Runtime.initialized:  # noqa: F823
+            col_path = [f"{self.cache_dir}/collections"]
             if self.version >= Version("2.15.0.dev0"):
                 # pylint: disable=import-outside-toplevel,no-name-in-module
                 from ansible.plugins.loader import init_plugin_loader
 
-                init_plugin_loader([])
+                init_plugin_loader(col_path)
             else:
                 # noinspection PyProtectedMember
                 from ansible.utils.collection_loader._collection_finder import (  # pylint: disable=import-outside-toplevel
@@ -142,10 +143,12 @@ class Runtime:
 
                 # noinspection PyProtectedMember
                 # pylint: disable=protected-access
+                col_path += self.config.collections_paths
+                col_path += [
+                    os.path.dirname(os.environ.get(ansible_collections_path(), "."))
+                ]
                 _AnsibleCollectionFinder(
-                    paths=[
-                        os.path.dirname(os.environ.get(ansible_collections_path(), "."))
-                    ]
+                    paths=col_path
                 )._install()  # pylint: disable=protected-access
             Runtime.initialized = True
 


### PR DESCRIPTION
- Ensure the cache dir is added to the collection loader path, in order to allow linting a collection role against a module this collection is providing

- Add missing default collection path to the loader for ansible version prior 2.15.0.dev0, as done by ansible's _configure_collection_loader(). The only remaining difference is the missing handling of COLLECTIONS_SCAN_SYS_PATH.

See https://github.com/ansible/ansible-lint/issues/2969 for reference.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>