### PR TITLE
Change install_collection to avoid use of -p

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,8 @@ commands =
   # pytest users to run coverage when they just want to run a single test with `pytest -k test`
   coverage run -m pytest {posargs:}
   sh -c "coverage xml || true && coverage report"
+  # We fail if files are modified at the end
+  git diff --exit-code
 commands_pre =
   # safety measure to assure we do not accidentally run tests with broken dependencies
   {envpython} -m pip check
@@ -63,6 +65,7 @@ setenv =
   FORCE_COLOR = 1
 allowlist_externals =
   ansible
+  git
   sh
 
 [testenv:lint]


### PR DESCRIPTION
As passing -p (target collection path destination) break ansible-galaxy
ability to find existing collection in other location, we avoid it
and use the environment variable approach instead.

Related: https://github.com/ansible/ansible-lint/issues/3251
