### PR TITLE
Partial revert "Finish pathlib migration (#245)"

### DIFF
--- a/src/ansible_compat/prerun.py
+++ b/src/ansible_compat/prerun.py
@@ -4,13 +4,13 @@ import os
 from pathlib import Path
 
 
-def get_cache_dir(project_dir: Path) -> Path:
+def get_cache_dir(project_dir: str) -> Path:
     """Compute cache directory to be used based on project path."""
     # we only use the basename instead of the full path in order to ensure that
     # we would use the same key regardless the location of the user home
     # directory or where the project is clones (as long the project folder uses
     # the same name).
-    basename = project_dir.resolve().name.encode(encoding="utf-8")
+    basename = Path(project_dir).resolve().name.encode(encoding="utf-8")
     # 6 chars of entropy should be enough
     cache_key = hashlib.sha256(basename).hexdigest()[:6]
     cache_dir = (

--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -402,7 +402,7 @@ class Runtime:
                     _logger.error(result.stderr)
                     raise AnsibleCommandError(result)
 
-    def prepare_environment(  # noqa: C901
+    def prepare_environment(
         self,
         required_collections: Optional[dict[str, str]] = None,
         *,

--- a/test/test_prerun.py
+++ b/test/test_prerun.py
@@ -6,6 +6,6 @@ from ansible_compat.prerun import get_cache_dir
 
 def test_get_cache_dir_relative() -> None:
     """Test behaviors of get_cache_dir."""
-    relative_path = Path(".")
-    abs_path = relative_path.resolve()
+    relative_path = "."
+    abs_path = str(Path(relative_path).resolve())
     assert get_cache_dir(relative_path) == get_cache_dir(abs_path)

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -493,7 +493,8 @@ def test_install_galaxy_role(runtime_tmp: Runtime) -> None:
         match="does not follow current galaxy requirements",
     ):
         runtime_tmp._install_galaxy_role(
-            str(runtime_tmp.project_dir), role_name_check=0
+            str(runtime_tmp.project_dir),
+            role_name_check=0,
         )
 
 
@@ -531,7 +532,8 @@ def test_install_galaxy_role_bad_namespace(runtime_tmp: Runtime) -> None:
     # this should raise an error regardless the role_name_check value
     with pytest.raises(AnsibleCompatError, match="Role namespace must be string, not"):
         runtime_tmp._install_galaxy_role(
-            str(runtime_tmp.project_dir), role_name_check=1
+            str(runtime_tmp.project_dir),
+            role_name_check=1,
         )
 
 

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -179,7 +179,7 @@ def test_runtime_install_requirements_missing_file() -> None:
     """Check that missing requirements file is ignored."""
     # Do not rely on this behavior, it may be removed in the future
     runtime = Runtime()
-    runtime.install_requirements(Path("/that/does/not/exist"))
+    runtime.install_requirements("/that/does/not/exist")
 
 
 @pytest.mark.parametrize(
@@ -214,7 +214,7 @@ def test_runtime_install_requirements_invalid_file(
         exc,
         match=msg,
     ):
-        runtime.install_requirements(file)
+        runtime.install_requirements(str(file))
 
 
 @contextmanager
@@ -484,15 +484,17 @@ def test_install_galaxy_role(runtime_tmp: Runtime) -> None:
     pathlib.Path(f"{runtime_tmp.project_dir}/meta").mkdir()
     pathlib.Path(f"{runtime_tmp.project_dir}/meta/main.yml").touch()
     # this should only raise a warning
-    runtime_tmp._install_galaxy_role(runtime_tmp.project_dir, role_name_check=1)
+    runtime_tmp._install_galaxy_role(str(runtime_tmp.project_dir), role_name_check=1)
     # this should test the bypass role name check path
-    runtime_tmp._install_galaxy_role(runtime_tmp.project_dir, role_name_check=2)
+    runtime_tmp._install_galaxy_role(str(runtime_tmp.project_dir), role_name_check=2)
     # this should raise an error
     with pytest.raises(
         InvalidPrerequisiteError,
         match="does not follow current galaxy requirements",
     ):
-        runtime_tmp._install_galaxy_role(runtime_tmp.project_dir, role_name_check=0)
+        runtime_tmp._install_galaxy_role(
+            str(runtime_tmp.project_dir), role_name_check=0
+        )
 
 
 def test_install_galaxy_role_unlink(
@@ -512,7 +514,7 @@ def test_install_galaxy_role_unlink(
 """,
         encoding="utf-8",
     )
-    runtime_tmp._install_galaxy_role(runtime_tmp.project_dir)
+    runtime_tmp._install_galaxy_role(str(runtime_tmp.project_dir))
     assert "symlink to current repository" in caplog.text
 
 
@@ -528,7 +530,9 @@ def test_install_galaxy_role_bad_namespace(runtime_tmp: Runtime) -> None:
     )
     # this should raise an error regardless the role_name_check value
     with pytest.raises(AnsibleCompatError, match="Role namespace must be string, not"):
-        runtime_tmp._install_galaxy_role(runtime_tmp.project_dir, role_name_check=1)
+        runtime_tmp._install_galaxy_role(
+            str(runtime_tmp.project_dir), role_name_check=1
+        )
 
 
 @pytest.mark.parametrize(
@@ -557,7 +561,7 @@ def test_install_galaxy_role_name_role_name_check_equals_to_1(
         encoding="utf-8",
     )
 
-    runtime_tmp._install_galaxy_role(runtime_tmp.project_dir, role_name_check=1)
+    runtime_tmp._install_galaxy_role(str(runtime_tmp.project_dir), role_name_check=1)
     assert "Computed fully qualified role name of " in caplog.text
 
 
@@ -572,7 +576,7 @@ def test_install_galaxy_role_no_checks(runtime_tmp: Runtime) -> None:
   namespace: acme
 """,
     )
-    runtime_tmp._install_galaxy_role(runtime_tmp.project_dir, role_name_check=2)
+    runtime_tmp._install_galaxy_role(str(runtime_tmp.project_dir), role_name_check=2)
     result = runtime_tmp.run(["ansible-galaxy", "list"])
     assert "- acme.foo," in result.stdout
     assert result.returncode == 0, result
@@ -700,10 +704,10 @@ def test_runtime_run(runtime: Runtime) -> None:
 
 def test_runtime_exec_cwd(runtime: Runtime) -> None:
     """Check if passing cwd works as expected."""
-    path = Path("/")
+    path = "/"
     result1 = runtime.run(["pwd"], cwd=path)
     result2 = runtime.run(["pwd"])
-    assert result1.stdout.rstrip() == str(path)
+    assert result1.stdout.rstrip() == path
     assert result1.stdout != result2.stdout
 
 


### PR DESCRIPTION
This reverts commit 2c25aebfc7e1d313f30238a2bad8a7b68e952fc8 for the an incompatible change to src/ansible_compat_prerun.py, as the get_cache_dir() function is called externally with a string argument.

Closes: #258