### PR TITLE
Revert "Automatically install tests/requirements.yml when found (#266)"

### DIFF
--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -489,8 +489,6 @@ class Runtime:
             "requirements.yml",
             "roles/requirements.yml",
             "collections/requirements.yml",
-            # These is more of less the official way to store test requirements in collections so far:
-            "tests/requirements.yml",
         ]:
             self.install_requirements(Path(req_file), retry=retry, offline=offline)
 

--- a/test/collections/acme.goodies/tests/requirements.yml
+++ b/test/collections/acme.goodies/tests/requirements.yml
@@ -1,3 +1,0 @@
-collections:
-  - name: ansible.posix
-    version: ">=1.0"

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -641,7 +641,6 @@ def test_runtime_version_in_range(
             "test/collections/acme.goodies",
             "default",
             [
-                "ansible.posix",  # from tests/requirements.yml
                 "ansible.utils",  # from galaxy.yml
                 "community.molecule",  # from galaxy.yml
             ],


### PR DESCRIPTION
This reverts commit f93bf7c611c4210c4e35fd1209626e288d699f6f.

tests/requirements.yml does not have the format that #266 assumed it to be. See my comments on IRC, in that PR, and also look at all existing instances of that files in gh.com/ansible-collections: https://github.com/search?q=org%3Aansible-collections+path%3A**%2Ftests%2Frequirements.yml&type=code - only two collections use the format the PR indicates, while 17 others do use the format as it was defined during the collection split in 2020. One of the two collections that uses the 'new' format only changed to that format in 2022 (https://github.com/ansible-collections/community.windows/commit/430e78e50866af332983c6a1e69e8dd9c50ef96e#diff-3c15561a763d4c893c12e2ee08880b8fd1a011b7c38c81973835bdf522069695), the other was only added in late 2022.

Thus assuming that tests/requirements.yml is a ansible-galaxy requirements file is simply wrong.

Fixes #270.