### PR TITLE
Improve requirements.yml detection

### DIFF
--- a/examples/reqs_broken/requirements.yml
+++ b/examples/reqs_broken/requirements.yml
@@ -1,0 +1,4 @@
+roles: []
+collections: []
+integration_tests_dependencies: [] # <-- invalid key
+unit_tests_dependencies: [] # <-- invalid key

--- a/src/ansible_compat/constants.py
+++ b/src/ansible_compat/constants.py
@@ -1,6 +1,16 @@
 """Constants used by ansible_compat."""
 
 
+REQUIREMENT_LOCATIONS = [
+    "requirements.yml",
+    "roles/requirements.yml",
+    "collections/requirements.yml",
+    # These is more of less the official way to store test requirements in collections so far, comments shows number of repos using this reported by https://sourcegraph.com/ at the time of writing
+    "tests/requirements.yml",  # 170
+    "tests/integration/requirements.yml",  # 3
+    "tests/unit/requirements.yml",  # 1
+]
+
 # Minimal version of Ansible we support for runtime
 ANSIBLE_MIN_VERSION = "2.12"
 

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -258,6 +258,13 @@ def test_prerun_reqs_v2(caplog: pytest.LogCaptureFixture, runtime: Runtime) -> N
         )
 
 
+def test_prerun_reqs_broken(runtime: Runtime) -> None:
+    """Checks that the we report invalid requirements.yml file."""
+    path = (Path(__file__).parent.parent / "examples" / "reqs_broken").resolve()
+    with cwd(path), pytest.raises(InvalidPrerequisiteError):
+        runtime.prepare_environment()
+
+
 def test__update_env_no_old_value_no_default_no_value(monkeypatch: MonkeyPatch) -> None:
     """Make sure empty value does not touch environment."""
     monkeypatch.delenv("DUMMY_VAR", raising=False)

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ setenv =
   PIP_DISABLE_PIP_VERSION_CHECK = 1
   PIP_CONSTRAINT = {toxinidir}/requirements.txt
   PRE_COMMIT_COLOR = always
-  PYTEST_REQPASS = 80
+  PYTEST_REQPASS = 81
   FORCE_COLOR = 1
 allowlist_externals =
   ansible


### PR DESCRIPTION
Gives explicit error message about invalid requirements.yml files, especially as an unsupported format was used during the 2020 split.

Closes: #274
Related: https://github.com/ansible-community/community-topics/issues/230
