### PR TITLE
Add smoke testing with ansible-lint

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -33,6 +33,7 @@ jobs:
             py39-ansible214
             py39-ansible215
             py311-devel
+            smoke
           platforms: linux,macos
           macos: minmax
   build:

--- a/tox.ini
+++ b/tox.ini
@@ -154,3 +154,22 @@ commands =
   mkdocs {posargs:build} --strict
 extras = docs
 passenv = *
+
+[testenv:smoke]
+description = Run ansible-lint own testing with current code from compat library
+commands_pre =
+  ansible localhost -m ansible.builtin.git -a 'repo=https://github.com/ansible/ansible-lint dest={envdir}/tmp/ansible-lint'
+  pip install -e "{envdir}/tmp/ansible-lint[test]"
+commands =
+  bash -c "pip freeze|grep ansible"
+  pytest -k role
+deps =
+  ansible-core
+setenv =
+  {[testenv]setenv}
+  PIP_CONSTRAINT = /dev/null
+  PYTEST_REQPASS = 0
+changedir = {envdir}/tmp/ansible-lint
+allowlist_externals =
+  pwd
+  bash


### PR DESCRIPTION
Adds a pipeline that checks ansible-lint test results with current version of ansible-compat.
Still expected to fail until we sort all the problems it uncovered.
