### PR TITLE
Add `sys.path` to collection paths

### DIFF
--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -201,10 +201,9 @@ class Runtime:
         if "PYTHONWARNINGS" not in self.environ:  # pragma: no cover
             self.environ["PYTHONWARNINGS"] = "ignore:Blowfish has been deprecated"
 
-        self.config = AnsibleConfig()
-
         if isolated:
             self.cache_dir = get_cache_dir(self.project_dir)
+        self.config = AnsibleConfig()
 
         # Add the sys.path to the collection paths if not isolated
         self._add_sys_path_to_collection_paths()

--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -238,7 +238,7 @@ class Runtime:
     def _add_sys_path_to_collection_paths(self) -> None:
         """Add the sys.path to the collection paths."""
         if not self.isolated and self.config.collections_scan_sys_path:
-            self.config.collections_paths.extend(sys.path)
+            self.config.collections_paths.extend(sys.path)  # pylint: disable=E1101
 
     def load_collections(self) -> None:
         """Load collection data."""

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -504,9 +504,12 @@ def test_scan_sys_path(
             version="0.1.0",
             install=False,
         )
+        raised_missing = False
     except InvalidPrerequisiteError:
-        if param.expected:
-            raise
+        raised_missing = True
+    
+    assert param.expected != raised_missing
+
 
 
 @pytest.mark.parametrize(

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -507,9 +507,8 @@ def test_scan_sys_path(
         raised_missing = False
     except InvalidPrerequisiteError:
         raised_missing = True
-    
-    assert param.expected != raised_missing
 
+    assert param.expected != raised_missing
 
 
 @pytest.mark.parametrize(

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import subprocess
 from contextlib import contextmanager
+from dataclasses import dataclass, fields
 from pathlib import Path
 from shutil import rmtree
 from typing import TYPE_CHECKING, Any
@@ -28,6 +29,8 @@ if TYPE_CHECKING:
 
     from _pytest.monkeypatch import MonkeyPatch
     from pytest_mock import MockerFixture
+
+V2_COLLECTION_TARBALL = Path("examples/reqs_v2/community-molecule-0.1.0.tar.gz")
 
 
 def test_runtime_version(runtime: Runtime) -> None:
@@ -442,6 +445,68 @@ def test_require_collection_preexisting_broken(tmp_path: pathlib.Path) -> None:
 def test_require_collection(runtime_tmp: Runtime) -> None:
     """Check that require collection successful install case."""
     runtime_tmp.require_collection("community.molecule", "0.1.0")
+
+
+@dataclass
+class ScanSysPath:
+    """Parameters for scan tests."""
+
+    isolated: bool
+    scan: bool
+    expected: bool
+
+    def __str__(self) -> str:
+        """Return a string representation of the object."""
+        parts = [
+            f"{field.name}{str(getattr(self, field.name))[0]}" for field in fields(self)
+        ]
+        return "-".join(parts)
+
+
+@pytest.mark.parametrize(
+    ("param"),
+    (
+        ScanSysPath(isolated=True, scan=True, expected=False),
+        ScanSysPath(isolated=True, scan=False, expected=False),
+        ScanSysPath(isolated=False, scan=True, expected=True),
+        ScanSysPath(isolated=False, scan=False, expected=False),
+    ),
+    ids=str,
+)
+def test_scan_sys_path(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+    runtime_tmp: Runtime,
+    param: ScanSysPath,
+) -> None:
+    """Confirm sys path is scanned for collections.
+
+    :param monkeypatch: Fixture for monkeypatching
+    :param tmp_path: Fixture for a temp directory
+    :param runtime_tmp: Fixture for a Runtime object
+    :param param: The parameters for the test
+    """
+    runtime_tmp.install_collection(
+        V2_COLLECTION_TARBALL,
+        destination=tmp_path,
+    )
+    runtime_tmp.config.collections_paths.remove(str(tmp_path))
+
+    # Set the runtime to the test parameters
+    runtime_tmp.isolated = param.isolated
+    runtime_tmp.config.collections_scan_sys_path = param.scan
+    monkeypatch.syspath_prepend(str(tmp_path))
+    runtime_tmp._add_sys_path_to_collection_paths()
+
+    try:
+        runtime_tmp.require_collection(
+            name="community.molecule",
+            version="0.1.0",
+            install=False,
+        )
+    except InvalidPrerequisiteError:
+        if param.expected:
+            raise
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ setenv =
   PIP_DISABLE_PIP_VERSION_CHECK = 1
   PIP_CONSTRAINT = {toxinidir}/requirements.txt
   PRE_COMMIT_COLOR = always
-  PYTEST_REQPASS = 85
+  PYTEST_REQPASS = 89
   FORCE_COLOR = 1
 allowlist_externals =
   ansible


### PR DESCRIPTION
Related: https://github.com/ansible/molecule/issues/4017

If not isolated and COLLECTION_SCAN_SYS_PATH is true, add the sys.paths to collection paths.

This is intended to mimic the functionality of the [collection loader](https://github.com/ansible/ansible/blob/9afaf2216b0bf38cfbd9a0c93409959f78d01820/lib/ansible/utils/collection_loader/_collection_finder.py#L254)