### PR TITLE
Revise site packages collection search test

### DIFF
--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -680,7 +680,7 @@ class Runtime:
         version: str | None = None,
         *,
         install: bool = True,
-    ) -> tuple[str, Path]:
+    ) -> tuple[CollectionVersion, Path]:
         """Check if a minimal collection version is present or exits.
 
         In the future this method may attempt to install a missing or outdated
@@ -740,7 +740,9 @@ class Runtime:
             if install:
                 self.install_collection(f"{name}:>={version}" if version else name)
                 return self.require_collection(
-                    name=name, version=version, install=False
+                    name=name,
+                    version=version,
+                    install=False,
                 )
             msg = f"Collection '{name}' not found in '{paths}'"
             _logger.fatal(msg)

--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -734,7 +734,7 @@ class Runtime:
                             msg = f"Found {name} collection {found_version} but {version} or newer is required."
                             _logger.fatal(msg)
                             raise InvalidPrerequisiteError(msg)
-                    return found_version, collpath
+                    return found_version, collpath.resolve()
                 break
         else:
             if install:

--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -739,7 +739,9 @@ class Runtime:
         else:
             if install:
                 self.install_collection(f"{name}:>={version}" if version else name)
-                return self.require_collection(name=name, version=version, install=False)
+                return self.require_collection(
+                    name=name, version=version, install=False
+                )
             msg = f"Collection '{name}' not found in '{paths}'"
             _logger.fatal(msg)
             raise InvalidPrerequisiteError(msg)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -94,7 +94,7 @@ class VirtualEnvironment:
         )
         return proc
 
-    def site_package_dirs(self) -> list[str]:
+    def site_package_dirs(self) -> list[Path]:
         """Get site packages.
 
         :return: List of site packages dirs

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -110,7 +110,8 @@ class VirtualEnvironment:
         if not isinstance(dirs, list):
             msg = "Expected list of site packages"
             raise TypeError(msg)
-        return dirs
+        sanitized = list({Path(d).resolve() for d in dirs})
+        return sanitized
 
 
 @pytest.fixture(scope="module")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,6 +33,7 @@ def runtime_tmp(
     yield instance
     instance.clean()
 
+
 def query_pkg_version(pkg: str) -> str:
     """Get the version of a current installed package.
 
@@ -41,6 +42,7 @@ def query_pkg_version(pkg: str) -> str:
     """
     return importlib.metadata.version(pkg)
 
+
 @pytest.fixture()
 def pkg_version() -> Callable[[str], str]:
     """Get the version of a current installed package.
@@ -48,7 +50,6 @@ def pkg_version() -> Callable[[str], str]:
     :return: Callable function to get package version
     """
     return query_pkg_version
-
 
 
 @pytest.fixture(scope="module")
@@ -62,6 +63,7 @@ def venv_module(tmp_path_factory: pytest.FixtureRequest) -> None:
     _venv = VirtualEnvironment(tmp_path)
     _venv.create()
     return _venv
+
 
 class VirtualEnvironment:
     """Virtualenv wrapper."""
@@ -108,9 +110,6 @@ class VirtualEnvironment:
 
         :return: List of site packages dirs
         """
-        script = (
-            "import json, site; "
-            "print(json.dumps(site.getsitepackages()))"
-        )
+        script = "import json, site; " "print(json.dumps(site.getsitepackages()))"
         proc = subprocess.check_output(args=[self.python, "-c", script], text=True)
         return json.loads(proc)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -101,7 +101,7 @@ class VirtualEnvironment:
         """
         script = "import json, site; print(json.dumps(site.getsitepackages()))"
         proc = subprocess.run(
-            args=[self.python, "-c", script],
+            args=[self.venv_python_path, "-c", script],
             capture_output=True,
             check=False,
             text=True,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -60,13 +60,14 @@ class VirtualEnvironment:
 
         :param path: Path to virtualenv
         """
-        self.path = path
-        self.bin_path = path / "bin"
-        self.python = self.bin_path / "python"
+        self.project = path
+        self.venv_path = self.project / "venv"
+        self.venv_bin_path = self.venv_path / "bin"
+        self.venv_python_path = self.venv_bin_path / "python"
 
     def create(self) -> None:
         """Create virtualenv."""
-        cmd = [str(sys.executable), "-m", "venv", str(self.path)]
+        cmd = [str(sys.executable), "-m", "venv", str(self.venv_path)]
         subprocess.check_call(args=cmd)
         # Install this package into the virtual environment
         self.install(f"{__file__}/../..")
@@ -76,17 +77,18 @@ class VirtualEnvironment:
 
         :param packages: Packages to install
         """
-        cmd = [str(self.python), "-m", "pip", "install", *packages]
+        cmd = [str(self.venv_python_path), "-m", "pip", "install", *packages]
         subprocess.check_call(args=cmd)
 
     def python_script_run(self, script: str) -> subprocess.CompletedProcess[str]:
-        """Run command in virtualenv.
+        """Run command in project dir using venv.
 
         :param args: Command to run
         """
         proc = subprocess.run(
-            args=[self.python, "-c", script],
+            args=[self.venv_python_path, "-c", script],
             capture_output=True,
+            cwd=self.project,
             check=False,
             text=True,
         )
@@ -118,7 +120,7 @@ def venv_module(tmp_path_factory: pytest.TempPathFactory) -> VirtualEnvironment:
     :param tmp_path: pytest fixture for temp path
     :return: VirtualEnvironment instance
     """
-    tmp_path = tmp_path_factory.mktemp("venv")
-    _venv = VirtualEnvironment(tmp_path)
+    test_project = tmp_path_factory.mktemp(basename="test_project-", numbered=True)
+    _venv = VirtualEnvironment(test_project)
     _venv.create()
     return _venv

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,12 @@
 """Pytest fixtures."""
+import importlib.metadata
+import json
 import pathlib
+import subprocess
+import sys
 from collections.abc import Generator
+from pathlib import Path
+from typing import Callable
 
 import pytest
 
@@ -26,3 +32,85 @@ def runtime_tmp(
     instance = Runtime(project_dir=tmp_path, isolated=True)
     yield instance
     instance.clean()
+
+def query_pkg_version(pkg: str) -> str:
+    """Get the version of a current installed package.
+
+    :param pkg: Package name
+    :return: Package version
+    """
+    return importlib.metadata.version(pkg)
+
+@pytest.fixture()
+def pkg_version() -> Callable[[str], str]:
+    """Get the version of a current installed package.
+
+    :return: Callable function to get package version
+    """
+    return query_pkg_version
+
+
+
+@pytest.fixture(scope="module")
+def venv_module(tmp_path_factory: pytest.FixtureRequest) -> None:
+    """Create a virtualenv in a temporary directory.
+
+    :param tmp_path: pytest fixture for temp path
+    :return: VirtualEnvironment instance
+    """
+    tmp_path = tmp_path_factory.mktemp("venv")
+    _venv = VirtualEnvironment(tmp_path)
+    _venv.create()
+    return _venv
+
+class VirtualEnvironment:
+    """Virtualenv wrapper."""
+
+    def __init__(self, path: Path) -> None:
+        """Initialize.
+
+        :param path: Path to virtualenv
+        """
+        self.path = path
+        self.bin_path = path / "bin"
+        self.python = self.bin_path / "python"
+
+    def create(self) -> None:
+        """Create virtualenv."""
+        cmd = [sys.executable, "-m", "venv", self.path]
+        subprocess.check_call(args=cmd)
+        # Install this package into the virtual environment
+        self.install(f"{__file__}/../..")
+
+    def install(self, *packages: str) -> None:
+        """Install packages in virtualenv.
+
+        :param packages: Packages to install
+        """
+        cmd = [self.python, "-m", "pip", "install", *packages]
+        subprocess.check_call(args=cmd)
+
+    def python_script_run(self, script: str) -> None:
+        """Run command in virtualenv.
+
+        :param args: Command to run
+        """
+        proc = subprocess.run(
+            args=[self.python, "-c", script],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        return proc
+
+    def site_package_dirs(self) -> list[str]:
+        """Get site packages.
+
+        :return: List of site packages dirs
+        """
+        script = (
+            "import json, site; "
+            "print(json.dumps(site.getsitepackages()))"
+        )
+        proc = subprocess.check_output(args=[self.python, "-c", script], text=True)
+        return json.loads(proc)

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -35,10 +35,6 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
-
-
-
-
 def test_runtime_version(runtime: Runtime) -> None:
     """Tests version property."""
     version = runtime.version
@@ -451,8 +447,6 @@ def test_require_collection_preexisting_broken(tmp_path: pathlib.Path) -> None:
 def test_require_collection(runtime_tmp: Runtime) -> None:
     """Check that require collection successful install case."""
     runtime_tmp.require_collection("community.molecule", "0.1.0")
-
-
 
 
 @pytest.mark.parametrize(

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -7,7 +7,6 @@ import os
 import pathlib
 import subprocess
 from contextlib import contextmanager
-from dataclasses import dataclass, fields
 from pathlib import Path
 from shutil import rmtree
 from typing import TYPE_CHECKING, Any
@@ -35,7 +34,9 @@ if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
     from pytest_mock import MockerFixture
 
-V2_COLLECTION_TARBALL = Path("examples/reqs_v2/community-molecule-0.1.0.tar.gz")
+
+
+
 
 
 def test_runtime_version(runtime: Runtime) -> None:
@@ -452,68 +453,6 @@ def test_require_collection(runtime_tmp: Runtime) -> None:
     runtime_tmp.require_collection("community.molecule", "0.1.0")
 
 
-@dataclass
-class ScanSysPath:
-    """Parameters for scan tests."""
-
-    isolated: bool
-    scan: bool
-    expected: bool
-
-    def __str__(self) -> str:
-        """Return a string representation of the object."""
-        parts = [
-            f"{field.name}{str(getattr(self, field.name))[0]}" for field in fields(self)
-        ]
-        return "-".join(parts)
-
-
-@pytest.mark.parametrize(
-    ("param"),
-    (
-        ScanSysPath(isolated=True, scan=True, expected=False),
-        ScanSysPath(isolated=True, scan=False, expected=False),
-        ScanSysPath(isolated=False, scan=True, expected=True),
-        ScanSysPath(isolated=False, scan=False, expected=False),
-    ),
-    ids=str,
-)
-def test_scan_sys_path(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
-    runtime_tmp: Runtime,
-    param: ScanSysPath,
-) -> None:
-    """Confirm sys path is scanned for collections.
-
-    :param monkeypatch: Fixture for monkeypatching
-    :param tmp_path: Fixture for a temp directory
-    :param runtime_tmp: Fixture for a Runtime object
-    :param param: The parameters for the test
-    """
-    runtime_tmp.install_collection(
-        V2_COLLECTION_TARBALL,
-        destination=tmp_path,
-    )
-    runtime_tmp.config.collections_paths.remove(str(tmp_path))
-
-    # Set the runtime to the test parameters
-    runtime_tmp.isolated = param.isolated
-    runtime_tmp.config.collections_scan_sys_path = param.scan
-    monkeypatch.syspath_prepend(str(tmp_path))
-    runtime_tmp._add_sys_path_to_collection_paths()
-
-    try:
-        runtime_tmp.require_collection(
-            name="community.molecule",
-            version="0.1.0",
-            install=False,
-        )
-        raised_missing = False
-    except InvalidPrerequisiteError:
-        raised_missing = True
-
-    assert param.expected != raised_missing
 
 
 @pytest.mark.parametrize(

--- a/test/test_runtime_scan_path.py
+++ b/test/test_runtime_scan_path.py
@@ -83,11 +83,11 @@ def test_scan_sys_path(
 
     proc = venv_module.python_script_run(script)
     if param.raises_not_found:
-        assert proc.returncode != 0
+        assert proc.returncode != 0, (proc.stdout, proc.stderr)
         assert "InvalidPrerequisiteError" in proc.stderr
         assert "'community.molecule' not found" in proc.stderr
     else:
-        assert proc.returncode == 0
+        assert proc.returncode == 0, (proc.stdout, proc.stderr)
         result = json.loads(proc.stdout)
         assert result["found_version"] == V2_COLLECTION_VERSION
         expected = first_site_package_dir / "ansible_collections" / V2_COLLECTION_NAMESPACE / V2_COLLECTION_NAME

--- a/test/test_runtime_scan_path.py
+++ b/test/test_runtime_scan_path.py
@@ -61,19 +61,21 @@ def test_scan_sys_path(
     :param param: The parameters for the test
     """
     first_site_package_dir = venv_module.site_package_dirs()[0]
-    # Install the collection into the venv site packages directory, force
-    # as of yet this test is not isolated from the rest of the system
-    runtime_tmp.install_collection(
-        collection=V2_COLLECTION_TARBALL,
-        destination=first_site_package_dir,
-        force=True,
-    )
+
     installed_to = (
         first_site_package_dir
         / "ansible_collections"
         / V2_COLLECTION_NAMESPACE
         / V2_COLLECTION_NAME
     )
+    if not installed_to.exists():
+        # Install the collection into the venv site packages directory, force
+        # as of yet this test is not isolated from the rest of the system
+        runtime_tmp.install_collection(
+            collection=V2_COLLECTION_TARBALL,
+            destination=first_site_package_dir,
+            force=True,
+        )
     # Confirm the collection is installed
     assert installed_to.exists()
     # Set the sys scan path environment variable

--- a/test/test_runtime_scan_path.py
+++ b/test/test_runtime_scan_path.py
@@ -68,7 +68,12 @@ def test_scan_sys_path(
         destination=first_site_package_dir,
         force=True,
     )
-    installed_to = first_site_package_dir / "ansible_collections" / V2_COLLECTION_NAMESPACE / V2_COLLECTION_NAME
+    installed_to = (
+        first_site_package_dir
+        / "ansible_collections"
+        / V2_COLLECTION_NAMESPACE
+        / V2_COLLECTION_NAME
+    )
     # Confirm the collection is installed
     assert installed_to.exists()
     # Set the sys scan path environment variable
@@ -96,4 +101,3 @@ def test_scan_sys_path(
         result = json.loads(proc.stdout)
         assert result["found_version"] == V2_COLLECTION_VERSION
         assert result["collection_path"] == str(installed_to)
-

--- a/test/test_runtime_scan_path.py
+++ b/test/test_runtime_scan_path.py
@@ -90,9 +90,6 @@ def test_scan_sys_path(
         assert proc.returncode == 0
         result = json.loads(proc.stdout)
         assert result["found_version"] == V2_COLLECTION_VERSION
-        assert Path(result["collection_path"]) == (
-            first_site_package_dir
-            / "ansible_collections"
-            / V2_COLLECTION_NAMESPACE
-            / V2_COLLECTION_NAME
-        )
+        expected = first_site_package_dir / "ansible_collections" / V2_COLLECTION_NAMESPACE / V2_COLLECTION_NAME
+        assert result["collection_path"] == str(expected)
+

--- a/test/test_runtime_scan_path.py
+++ b/test/test_runtime_scan_path.py
@@ -1,0 +1,91 @@
+"""Test the scan path functionality of the runtime."""
+
+import json
+import textwrap
+from dataclasses import dataclass, fields
+from pathlib import Path
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+
+from ansible_compat.runtime import Runtime
+
+from .conftest import VirtualEnvironment
+
+V2_COLLECTION_TARBALL = Path("examples/reqs_v2/community-molecule-0.1.0.tar.gz")
+V2_COLLECTION_NAMESPACE= "community"
+V2_COLLECTION_NAME = "molecule"
+V2_COLLECTION_VERSION = "0.1.0"
+V2_COLLECTION_FULL_NAME = f"{V2_COLLECTION_NAMESPACE}.{V2_COLLECTION_NAME}"
+
+
+
+@dataclass
+class ScanSysPath:
+    """Parameters for scan tests."""
+
+    isolated: bool
+    scan: bool
+    expected: bool
+
+    def __str__(self) -> str:
+        """Return a string representation of the object."""
+        parts = [
+            f"{field.name}{str(getattr(self, field.name))[0]}" for field in fields(self)
+        ]
+        return "-".join(parts)
+
+
+@pytest.mark.parametrize(
+    ("param"),
+    (
+        ScanSysPath(isolated=True, scan=True, expected=False),
+        ScanSysPath(isolated=True, scan=False, expected=False),
+        ScanSysPath(isolated=False, scan=True, expected=True),
+        ScanSysPath(isolated=False, scan=False, expected=False),
+    ),
+    ids=str,
+)
+def test_scan_sys_path(
+    venv_module: VirtualEnvironment,
+    monkeypatch: MonkeyPatch,
+    runtime_tmp: Runtime,
+    param: ScanSysPath,
+) -> None:
+    """Confirm sys path is scanned for collections.
+
+    :param venv_module: Fixture for a virtual environment
+    :param monkeypatch: Fixture for monkeypatching
+    :param runtime_tmp: Fixture for a Runtime object
+    :param param: The parameters for the test
+    """
+    first_site_package_dir = venv_module.site_package_dirs()[0]
+    # Install the collection into the venv site packages directory
+    runtime_tmp.install_collection(V2_COLLECTION_TARBALL, destination=first_site_package_dir)
+    # Set the sys scan path environment variable
+    monkeypatch.setenv("ANSIBLE_COLLECTIONS_SCAN_SYS_PATH", str(param.scan))
+    # Set the ansible collections paths to nothing as a safeguard
+    monkeypatch.setenv("ANSIBLE_COLLECTIONS_PATHS", "")
+
+
+    script = textwrap.dedent(f"""
+    import json;
+    from ansible_compat.runtime import Runtime;
+    r = Runtime(isolated={param.isolated});
+    fv, cp = r.require_collection(name="{V2_COLLECTION_FULL_NAME}", version="{V2_COLLECTION_VERSION}", install=False);
+    print(json.dumps({{"found_version": str(fv), "collection_path": str(cp)}}));
+    """)
+
+    proc = venv_module.python_script_run(script)
+    assert bool(proc.returncode) is not param.expected
+    if not param.expected:
+        assert "\'community.molecule\' not found" in proc.stderr
+    else:
+        result = json.loads(proc.stdout)
+        assert result["found_version"] == V2_COLLECTION_VERSION
+        assert Path(result["collection_path"]) == (
+            Path(first_site_package_dir) /
+            "ansible_collections" /
+            V2_COLLECTION_NAMESPACE /
+            V2_COLLECTION_NAME
+        )

--- a/test/test_runtime_scan_path.py
+++ b/test/test_runtime_scan_path.py
@@ -68,8 +68,8 @@ def test_scan_sys_path(
     )
     # Set the sys scan path environment variable
     monkeypatch.setenv("ANSIBLE_COLLECTIONS_SCAN_SYS_PATH", str(param.scan))
-    # Set the ansible collections paths to a tmp path as a safeguard
-    monkeypatch.setenv("ANSIBLE_COLLECTIONS_PATHS", str(tmp_path))
+    # Set the ansible collections paths to avoid bleed from other tests
+    monkeypatch.setenv("ANSIBLE_COLLECTIONS_PATH", str(tmp_path))
 
     script = textwrap.dedent(
         f"""

--- a/test/test_runtime_scan_path.py
+++ b/test/test_runtime_scan_path.py
@@ -49,6 +49,7 @@ def test_scan_sys_path(
     venv_module: VirtualEnvironment,
     monkeypatch: MonkeyPatch,
     runtime_tmp: Runtime,
+    tmp_path: Path,
     param: ScanSysPath,
 ) -> None:
     """Confirm sys path is scanned for collections.
@@ -56,6 +57,7 @@ def test_scan_sys_path(
     :param venv_module: Fixture for a virtual environment
     :param monkeypatch: Fixture for monkeypatching
     :param runtime_tmp: Fixture for a Runtime object
+    :param tmp_dir: Fixture for a temporary directory
     :param param: The parameters for the test
     """
     first_site_package_dir = Path(venv_module.site_package_dirs()[0])
@@ -66,8 +68,8 @@ def test_scan_sys_path(
     )
     # Set the sys scan path environment variable
     monkeypatch.setenv("ANSIBLE_COLLECTIONS_SCAN_SYS_PATH", str(param.scan))
-    # Set the ansible collections paths to nothing as a safeguard
-    monkeypatch.setenv("ANSIBLE_COLLECTIONS_PATHS", "")
+    # Set the ansible collections paths to a tmp path as a safeguard
+    monkeypatch.setenv("ANSIBLE_COLLECTIONS_PATHS", str(tmp_path))
 
     script = textwrap.dedent(
         f"""


### PR DESCRIPTION
Revises #318 

This test may seem a little expensive, but rather than modify the current runtime enviroment for pytest by installing the collection into one of the current paths, install the collection into a module scoped virtual enviromnet site packages directory.

This will avoid a conflict with a test that is being simultaniously run because the venv is scoped to the module.

The test was moved into it's own file to reflect the scope of the venv fixture and avoid conflict in the future with other tests that may use it.

The return value of `require_collection` was also modified to provide the version and location of the collection found so it could be used within the test. 

