### PR TITLE
Catch empty collection lists

### DIFF
--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -548,7 +548,7 @@ class Runtime:
                     raise AnsibleCommandError(result)
 
         # Run galaxy collection install works on v2 requirements.yml
-        if "collections" in reqs_yaml:
+        if "collections" in reqs_yaml and reqs_yaml["collections"] is not None:
             cmd = [
                 "ansible-galaxy",
                 "collection",


### PR DESCRIPTION
A file with just `collections:` in it leads to `{'collections':None}` which makes the loop sad.  Easier to catch it here.

Fixes #4034