### PR TITLE
Remove isolated option while adding sys.path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ concurrency = ["multiprocessing", "thread"]
 
 [tool.coverage.report]
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]
-fail_under = 93
+fail_under = 91
 skip_covered = true
 show_missing = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ concurrency = ["multiprocessing", "thread"]
 
 [tool.coverage.report]
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]
-fail_under = 91
+fail_under = 92
 skip_covered = true
 show_missing = true
 

--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -238,7 +238,7 @@ class Runtime:
 
     def _add_sys_path_to_collection_paths(self) -> None:
         """Add the sys.path to the collection paths."""
-        if not self.isolated and self.config.collections_scan_sys_path:
+        if self.config.collections_scan_sys_path:
             for path in sys.path:
                 if (
                     path not in self.config.collections_paths

--- a/test/test_runtime_scan_path.py
+++ b/test/test_runtime_scan_path.py
@@ -23,7 +23,6 @@ V2_COLLECTION_FULL_NAME = f"{V2_COLLECTION_NAMESPACE}.{V2_COLLECTION_NAME}"
 class ScanSysPath:
     """Parameters for scan tests."""
 
-    isolated: bool
     scan: bool
     raises_not_found: bool
 
@@ -38,10 +37,8 @@ class ScanSysPath:
 @pytest.mark.parametrize(
     ("param"),
     (
-        ScanSysPath(isolated=True, scan=True, raises_not_found=True),
-        ScanSysPath(isolated=True, scan=False, raises_not_found=True),
-        ScanSysPath(isolated=False, scan=True, raises_not_found=False),
-        ScanSysPath(isolated=False, scan=False, raises_not_found=True),
+        ScanSysPath(scan=False, raises_not_found=True),
+        ScanSysPath(scan=True, raises_not_found=False),
     ),
     ids=str,
 )
@@ -87,7 +84,7 @@ def test_scan_sys_path(
         f"""
     import json;
     from ansible_compat.runtime import Runtime;
-    r = Runtime(isolated={param.isolated});
+    r = Runtime();
     fv, cp = r.require_collection(name="{V2_COLLECTION_FULL_NAME}", version="{V2_COLLECTION_VERSION}", install=False);
     print(json.dumps({{"found_version": str(fv), "collection_path": str(cp)}}));
     """,

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ setenv =
   PIP_DISABLE_PIP_VERSION_CHECK = 1
   PIP_CONSTRAINT = {toxinidir}/requirements.txt
   PRE_COMMIT_COLOR = always
-  PYTEST_REQPASS = 93
+  PYTEST_REQPASS = 91
   FORCE_COLOR = 1
 allowlist_externals =
   ansible


### PR DESCRIPTION
This PR validates the usage of `isolated` while adding sys.path to collections path.

Closes: https://github.com/ansible/ansible-compat/issues/324