### PR TITLE
Add has_playbook method to Runtime

### DIFF
--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -893,3 +893,16 @@ def test_get_galaxy_role_name_invalid() -> None:
         "role_name": False,  # <-- invalid data, should be string
     }
     assert _get_galaxy_role_name(galaxy_infos) == ""
+
+
+def test_runtime_has_playbook() -> None:
+    """Tests has_playbook method."""
+    runtime = Runtime(require_module=True)
+
+    assert not runtime.has_playbook("this-does-not-exist.yml")
+    # call twice to ensure cache is used:
+    assert not runtime.has_playbook("this-does-not-exist.yml")
+
+    assert not runtime.has_playbook("this-does-not-exist.yml", basedir=Path())
+    # this is part of community.molecule collection
+    assert runtime.has_playbook("community.molecule.validate.yml")

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ setenv =
   PIP_DISABLE_PIP_VERSION_CHECK = 1
   PIP_CONSTRAINT = {toxinidir}/.config/constraints.txt
   PRE_COMMIT_COLOR = always
-  PYTEST_REQPASS = 93
+  PYTEST_REQPASS = 94
   FORCE_COLOR = 1
 allowlist_externals =
   ansible


### PR DESCRIPTION
Add functionality for detecting if Ansible can find specific playbooks, caching the results. This is useful as they can reside inside collections.

Related: https://github.com/ansible/ansible-lint/pull/4141
