### PR TITLE
Don't nuke the collections path

### DIFF
--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -392,7 +392,9 @@ class Runtime:
         # https://github.com/ansible/ansible-lint/issues/3522
         env["ANSIBLE_VERBOSE_TO_STDERR"] = "True"
 
-        env["ANSIBLE_COLLECTIONS_PATH"] = ":".join(self.config.collections_paths)
+        # Assume the caller has a proper env, if not use a sane default
+        if "ANSIBLE_COLLECTIONS_PATH" not in env:
+            env["ANSIBLE_COLLECTIONS_PATH"] = ":".join(self.config.collections_paths)
 
         for _ in range(self.max_retries + 1 if retry else 1):
             result = run_func(


### PR DESCRIPTION
An issue was found with molecule during testing where the collection path was set to the ephemeral directory, an env properly constructed, but then compat nuked the COLLECTION_PATH from the env var.

I think we can assume the caller here has properly constructed the path they wish to use, if not fall back to the previous default