### PR TITLE
Skip coverage for `if TYPE_CHECKING` blocks

### DIFF
--- a/src/ansible_compat/config.py
+++ b/src/ansible_compat/config.py
@@ -16,7 +16,7 @@ from ansible_compat.constants import ANSIBLE_MIN_VERSION
 from ansible_compat.errors import InvalidPrerequisiteError, MissingAnsibleError
 from ansible_compat.ports import cache
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from pathlib import Path
 
 

--- a/src/ansible_compat/errors.py
+++ b/src/ansible_compat/errors.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from ansible_compat.constants import ANSIBLE_MISSING_RC, INVALID_PREREQUISITES_RC
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from subprocess import CompletedProcess
 
 

--- a/src/ansible_compat/loaders.py
+++ b/src/ansible_compat/loaders.py
@@ -8,7 +8,7 @@ import yaml
 
 from ansible_compat.errors import InvalidPrerequisiteError
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from pathlib import Path
 
 

--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -42,7 +42,7 @@ from ansible_compat.errors import (
 from ansible_compat.loaders import colpath_from_path, yaml_from_file
 from ansible_compat.prerun import get_cache_dir
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     # https://github.com/PyCQA/pylint/issues/3240
     # pylint: disable=unsubscriptable-object
     CompletedProcess = subprocess.CompletedProcess[Any]

--- a/src/ansible_compat/schema.py
+++ b/src/ansible_compat/schema.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import jsonschema
 from jsonschema.validators import validator_for
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ansible_compat.types import JSON
 
 


### PR DESCRIPTION
This used to be done automatically, but they are no longer being skipped on codecov