### PR TITLE
Updated dead links in constants.py

### DIFF
--- a/src/ansible_compat/constants.py
+++ b/src/ansible_compat/constants.py
@@ -33,8 +33,8 @@ galaxy_info:
 role_name: my_name  # if absent directory name hosting role is used instead
 namespace: my_galaxy_namespace  # if absent, author is used instead
 
-Namespace: https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/usage_guide/collections/#namespaces
-Role: https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/dev/developer_guide/rbac/?h=creating+role#role-assignment
+Namespace: https://old-galaxy.ansible.com/docs/contributing/namespaces.html#galaxy-namespace-limitations
+Role: https://old-galaxy.ansible.com/docs/contributing/creating_role.html#role-names 
 
 As an alternative, you can add 'role-name' to either skip_list or warn_list.
 """

--- a/src/ansible_compat/constants.py
+++ b/src/ansible_compat/constants.py
@@ -33,8 +33,8 @@ galaxy_info:
 role_name: my_name  # if absent directory name hosting role is used instead
 namespace: my_galaxy_namespace  # if absent, author is used instead
 
-Namespace: https://galaxy.ansible.com/docs/contributing/namespaces.html#galaxy-namespace-limitations
-Role: https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names
+Namespace: https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/usage_guide/collections/#permissions
+Role: https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/dev/developer_guide/rbac/?h=creating+role#role-assignment
 
 As an alternative, you can add 'role-name' to either skip_list or warn_list.
 """

--- a/src/ansible_compat/constants.py
+++ b/src/ansible_compat/constants.py
@@ -34,7 +34,7 @@ role_name: my_name  # if absent directory name hosting role is used instead
 namespace: my_galaxy_namespace  # if absent, author is used instead
 
 Namespace: https://old-galaxy.ansible.com/docs/contributing/namespaces.html#galaxy-namespace-limitations
-Role: https://old-galaxy.ansible.com/docs/contributing/creating_role.html#role-names 
+Role: https://old-galaxy.ansible.com/docs/contributing/creating_role.html#role-names
 
 As an alternative, you can add 'role-name' to either skip_list or warn_list.
 """

--- a/src/ansible_compat/constants.py
+++ b/src/ansible_compat/constants.py
@@ -33,7 +33,7 @@ galaxy_info:
 role_name: my_name  # if absent directory name hosting role is used instead
 namespace: my_galaxy_namespace  # if absent, author is used instead
 
-Namespace: https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/usage_guide/collections/#permissions
+Namespace: https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/usage_guide/collections/#namespaces
 Role: https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/dev/developer_guide/rbac/?h=creating+role#role-assignment
 
 As an alternative, you can add 'role-name' to either skip_list or warn_list.


### PR DESCRIPTION
"Fixes: https://github.com/ansible/ansible-compat/issues/396"
## Overview

This pull request updates outdated and non-functional links in the `constants.py` file of the `ansible-combat` project. The affected sections include `namespaces` and `roles`.

## Changes Made

- Replaced outdated links in the `namespaces` section with updated, functional links.
- Updated broken links in the `roles` section to point to current, valid resources.

## Details

- The `constants.py` file now contains valid URLs that are relevant and accessible.
- No functional code changes have been made; only link updates were performed to ensure resource availability.

