### PR TITLE
Updated Dependency : types-pkg-resources to types-setuptools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,7 +87,7 @@ repos:
           - subprocess-tee>=0.4.1
           - "typing-extensions>=4.5.0;python_version<'3.10'"
           - types-PyYAML
-          - types-pkg_resources
+          - types-setuptools
           - types-jsonschema>=4.4.9
   - repo: https://github.com/pycqa/pylint
     rev: v3.2.4

--- a/src/ansible_compat/constants.py
+++ b/src/ansible_compat/constants.py
@@ -33,8 +33,8 @@ galaxy_info:
 role_name: my_name  # if absent directory name hosting role is used instead
 namespace: my_galaxy_namespace  # if absent, author is used instead
 
-Namespace: https://galaxy.ansible.com/docs/contributing/namespaces.html#galaxy-namespace-limitations
-Role: https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names
+Namespace: https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/usage_guide/collections/#namespaces
+Role: https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/dev/developer_guide/rbac/?h=creating+role#role-assignment
 
 As an alternative, you can add 'role-name' to either skip_list or warn_list.
 """

--- a/src/ansible_compat/constants.py
+++ b/src/ansible_compat/constants.py
@@ -33,8 +33,8 @@ galaxy_info:
 role_name: my_name  # if absent directory name hosting role is used instead
 namespace: my_galaxy_namespace  # if absent, author is used instead
 
-Namespace: https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/usage_guide/collections/#namespaces
-Role: https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/dev/developer_guide/rbac/?h=creating+role#role-assignment
+Namespace: https://galaxy.ansible.com/docs/contributing/namespaces.html#galaxy-namespace-limitations
+Role: https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names
 
 As an alternative, you can add 'role-name' to either skip_list or warn_list.
 """

--- a/src/ansible_compat/schema.py
+++ b/src/ansible_compat/schema.py
@@ -102,8 +102,8 @@ def validate(
                 data_path=to_path(validation_error.absolute_path),
                 json_path=json_path(validation_error.absolute_path),
                 schema_path=to_path(validation_error.schema_path),
-                relative_schema=validation_error.schema,
-                expected=validation_error.validator_value,
+                relative_schema=str(validation_error.schema),
+                expected=str(validation_error.validator_value),
                 validator=str(validation_error.validator),
                 found=str(validation_error.instance),
             )

--- a/test/assets/validate0_expected.json
+++ b/test/assets/validate0_expected.json
@@ -4,7 +4,7 @@
     "data_path": "environment.a",
     "json_path": "$.environment.a",
     "schema_path": "properties.environment.additionalProperties.type",
-    "relative_schema": { "type": "string" },
+    "relative_schema": "{'type': 'string'}",
     "expected": "string",
     "validator": "type",
     "found": "False"
@@ -14,7 +14,7 @@
     "data_path": "environment.b",
     "json_path": "$.environment.b",
     "schema_path": "properties.environment.additionalProperties.type",
-    "relative_schema": { "type": "string" },
+    "relative_schema": "{'type': 'string'}",
     "expected": "string",
     "validator": "type",
     "found": "True"


### PR DESCRIPTION
- Update pre-commit hook to replace yanked types-pkg-resources with types-setuptools

- All versions of types-pkg_resources have been marked as yanked. Updated the dependency to types-setuptools as specified on PyPI (https://pypi.org/project/types-pkg-resources/). This ensures compatibility and resolves the package installation error.  And it solves the issue during the "[pre-commit.ci](http://pre-commit.ci/) - pr — error during build" check (https://github.com/ansible/ansible-compat/pull/397), specifically related to the types-pkg_resources package.
