### PR TITLE
provide more detail on multile collection installs

### DIFF
--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -309,7 +309,7 @@ class Runtime:
                     raise TypeError(msg)
 
                 if collection in self.collections:
-                    msg = f"Multiple versions of '{collection}' were found installed, only the first one will be used, {self.collections[collection].version} ({self.collections[collection].path})."
+                    msg = f"Another version of '{collection}' {collection_info['version']} was found installed in {path}, only the first one will be used, {self.collections[collection].version} ({self.collections[collection].path})."
                     logging.warning(msg)
                 else:
                     self.collections[collection] = Collection(


### PR DESCRIPTION
When multiple versions of a collection are installed it is not currently clear where the other version is, this patch gives a bit more detail

Before...

WARNING  Multiple versions of 'ansible.posix' were found installed, only the first one will be used, 1.5.1 (/home/blah/.ansible/collections/ansible_collections).

After...

WARNING  Another version of 'ansible.posix' 1.5.4 was found installed in /home/blah/yard/systems/.venv/lib/python3.11/site-packages/ansible_collections, only the first one will be used, 1.5.1 (/home/blah/.ansible/collections/ansible_collections).