### PR TITLE
Fix grammatical error in collection path info message

### DIFF
--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -292,7 +292,7 @@ class Runtime:
 
             if collections_paths != self.config.collections_paths:
                 _logger.info(
-                    "Collection paths was patch to include extra directories %s",
+                    "Collection paths was patched to include extra directories %s",
                     ",".join(collections_paths),
                 )
         else:


### PR DESCRIPTION
Fix the language in info message about patching collection paths.

Simple two letter fix.