### PR TITLE
Avoid get_cache_dir errors with read only virtualenvs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -42,6 +42,16 @@ jobs:
   - job: tests
     trigger: pull_request
     branch: main
+    require:
+      label:
+        present:
+          - bug
+          - dependencies
+          - enhancement
+          - major
+          - minor
+        absent:
+          - skip-changelog
     targets:
       - fedora-latest
       - fedora-rawhide

--- a/src/ansible_compat/prerun.py
+++ b/src/ansible_compat/prerun.py
@@ -3,7 +3,24 @@
 import hashlib
 import os
 import tempfile
+import warnings
 from pathlib import Path
+
+
+def is_writable(path: Path) -> bool:
+    """Check if path is writable, creating if necessary.
+
+    Args:
+        path: Path to check.
+
+    Returns:
+        True if path is writable, False otherwise.
+    """
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return False
+    return path.exists() and os.access(path, os.W_OK)
 
 
 def get_cache_dir(project_dir: Path, *, isolated: bool = True) -> Path:
@@ -14,31 +31,51 @@ def get_cache_dir(project_dir: Path, *, isolated: bool = True) -> Path:
         isolated: Whether to use isolated cache directory.
 
     Returns:
-        Cache directory path.
+        A writable cache directory.
 
     Raises:
         RuntimeError: if cache directory is not writable.
+        OSError: if cache directory cannot be created.
     """
-    cache_dir = Path(os.environ.get("ANSIBLE_HOME", "~/.ansible")).expanduser()
-
+    cache_dir: Path | None = None
     if "VIRTUAL_ENV" in os.environ:
-        path = Path(os.environ["VIRTUAL_ENV"])
-        if not path.exists():  # pragma: no cover
-            msg = f"VIRTUAL_ENV={os.environ['VIRTUAL_ENV']} does not exist."
-            raise RuntimeError(msg)
-        cache_dir = path.resolve() / ".ansible"
-    elif isolated:
-        if not project_dir.exists() or not os.access(project_dir, os.W_OK):
-            # As "project_dir" can also be "/" and user might not be able
-            # to write to it, we use a temporary directory as fallback.
-            checksum = hashlib.sha256(
-                project_dir.as_posix().encode("utf-8"),
-            ).hexdigest()[:4]
-
-            cache_dir = Path(tempfile.gettempdir()) / f".ansible-{checksum}"
-            cache_dir.mkdir(parents=True, exist_ok=True)
+        path = Path(os.environ["VIRTUAL_ENV"]).resolve() / ".ansible"
+        if is_writable(path):
+            cache_dir = path
         else:
-            cache_dir = project_dir.resolve() / ".ansible"
+            msg = f"Found VIRTUAL_ENV={os.environ['VIRTUAL_ENV']} but we cannot use it for caching as it is not writable."
+            warnings.warn(
+                message=msg,
+                stacklevel=2,
+                source={"msg": msg},
+            )
+
+    if isolated:
+        project_dir = project_dir.resolve() / ".ansible"
+        if is_writable(project_dir):
+            cache_dir = project_dir
+        else:
+            msg = f"Project directory {project_dir} cannot be used for caching as it is not writable."
+            warnings.warn(msg, stacklevel=2)
+    else:
+        cache_dir = Path(os.environ.get("ANSIBLE_HOME", "~/.ansible")).expanduser()
+        # This code should be never be reached because import from ansible-core
+        #  would trigger a fatal error if this location is not writable.
+        if not is_writable(cache_dir):  # pragma: no cover
+            msg = f"Cache directory {cache_dir} is not writable."
+            raise OSError(msg)
+
+    if not cache_dir:
+        # As "project_dir" can also be "/" and user might not be able
+        # to write to it, we use a temporary directory as fallback.
+        checksum = hashlib.sha256(
+            project_dir.as_posix().encode("utf-8"),
+        ).hexdigest()[:4]
+
+        cache_dir = Path(tempfile.gettempdir()) / f".ansible-{checksum}"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        msg = f"Using unique temporary directory {cache_dir} for caching."
+        warnings.warn(msg, stacklevel=2)
 
     # Ensure basic folder structure exists so `ansible-galaxy list` does not
     # fail with: None of the provided paths were usable. Please specify a valid path with
@@ -49,4 +86,5 @@ def get_cache_dir(project_dir: Path, *, isolated: bool = True) -> Path:
         msg = "Failed to create cache directory."
         raise RuntimeError(msg) from exc
 
+    # We succeed only if the path is writable.
     return cache_dir

--- a/test/test_prerun.py
+++ b/test/test_prerun.py
@@ -6,6 +6,8 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
+
 if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
 
@@ -50,5 +52,41 @@ def test_get_cache_dir_isolation_no_venv_root(monkeypatch: MonkeyPatch) -> None:
     """
     monkeypatch.delenv("VIRTUAL_ENV", raising=False)
     monkeypatch.delenv("ANSIBLE_HOME", raising=False)
-    cache_dir = get_cache_dir(Path("/"), isolated=True)
+    with (
+        pytest.warns(
+            UserWarning,
+            match=r"Project directory /.ansible cannot be used for caching as it is not writable.",
+        ),
+        pytest.warns(
+            UserWarning,
+            match=r"Using unique temporary directory .* for caching.",
+        ),
+    ):
+        cache_dir = get_cache_dir(Path("/"), isolated=True)
+    assert cache_dir.as_posix().startswith(tempfile.gettempdir())
+
+
+def test_get_cache_dir_venv_ro_project_ro(monkeypatch: MonkeyPatch) -> None:
+    """Test behaviors of get_cache_dir with read-only virtual environment and read only project directory.
+
+    Args:
+        monkeypatch: Pytest fixture for monkeypatching
+    """
+    monkeypatch.setenv("VIRTUAL_ENV", "/")
+    monkeypatch.delenv("ANSIBLE_HOME", raising=False)
+    with (
+        pytest.warns(
+            UserWarning,
+            match=r"Using unique temporary directory .* for caching.",
+        ),
+        pytest.warns(
+            UserWarning,
+            match=r"Found VIRTUAL_ENV=/ but we cannot use it for caching as it is not writable.",
+        ),
+        pytest.warns(
+            UserWarning,
+            match=r"Project directory .* cannot be used for caching as it is not writable.",
+        ),
+    ):
+        cache_dir = get_cache_dir(Path("/etc"), isolated=True)
     assert cache_dir.as_posix().startswith(tempfile.gettempdir())


### PR DESCRIPTION
Fixes: https://github.com/ansible/ansible-lint/issues/4501
Fixes: #455