### PR TITLE
Reduce number of cases when we test RPM building

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -21,6 +21,16 @@ jobs:
   - job: copr_build
     trigger: pull_request
     branch: main
+    require:
+      label:
+        present:
+          - bug
+          - dependencies
+          - enhancement
+          - major
+          - minor
+        absent:
+          - skip-changelog
     targets:
       - fedora-rawhide-x86_64
       - fedora-rawhide-aarch64


### PR DESCRIPTION
As https://github.com/packit/packit-service/issues/2006 is not yet available, we can only rely on labels to reduce number of cases where we test RPM building.