### PR TITLE
Avoid get_cache_dir errors with read only virtualenvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ src/ansible_compat/_version.py
 node_modules
 _readthedocs
 test/roles/acme.missing_deps/.ansible
+.ansible

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,7 +87,7 @@ repos:
         # empty args needed in order to match mypy cli behavior
         args: ["--strict"]
         additional_dependencies:
-          - ansible-core
+          - ansible-core>=2.16.0
           - cached_property
           - packaging
           - pytest


### PR DESCRIPTION
Fixes: https://github.com/ansible/ansible-lint/issues/4501
Fixes: #455