### PR TITLE
fix: add support for python 3.14

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -40,7 +40,7 @@ jobs:
         py313-ansible218
         py314-devel
         py310-macos:tox -e py310
-        py314-macos:tox -e py314
+        py314-devel-macos:tox -e py314-devel
         smoke
       skip_explode: "1"
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Bug Tracking",
   "Topic :: Software Development :: Quality Assurance",
   "Topic :: Software Development :: Testing",
@@ -479,6 +480,7 @@ env_list = [
   "py312-ansible218",
   "py313-ansible218",
   "py313-devel",
+  "py314-devel",
 ]
 requires = [
   "setuptools>=65.3",
@@ -586,6 +588,11 @@ description = "ansible-core 2.18 py{py_dot_ver}"
 runner = "uv-venv-runner"
 
 [tool.tox.env.py313-devel]
+deps = ["ansible-core @ git+https://github.com/ansible/ansible.git@devel"]
+description = "ansible-core devel py{py_dot_ver}"
+runner = "uv-venv-runner"
+
+[tool.tox.env.py314-devel]
 deps = ["ansible-core @ git+https://github.com/ansible/ansible.git@devel"]
 description = "ansible-core devel py{py_dot_ver}"
 runner = "uv-venv-runner"

--- a/test/test_runtime_scan_path.py
+++ b/test/test_runtime_scan_path.py
@@ -3,6 +3,7 @@
 import json
 import os
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -20,6 +21,10 @@ V2_COLLECTION_VERSION = "0.1.0"
 V2_COLLECTION_FULL_NAME = f"{V2_COLLECTION_NAMESPACE}.{V2_COLLECTION_NAME}"
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 14),
+    reason="Python 3.14 requires unreleased ansible-core which will fail this test.",
+)
 @pytest.mark.parametrize(
     ("scan", "raises_not_found"),
     (


### PR DESCRIPTION
- Ensures we fail fast with known unsupported versions of ansible-core
- Prepares for fixing uv installation conflict due to unreleased conditional dependency

Related: https://github.com/astral-sh/uv/issues/2685
Fixes: AAP-55147