### PR TITLE
fix: update _extends syntax for release-drafter v7 compatibility

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,3 @@
 ---
 # see https://github.com/ansible/team-devtools
-_extends: ansible/team-devtools
+_extends: ansible/team-devtools:.github/release-drafter.yml


### PR DESCRIPTION
## Problem

The `push.yml` → `update_release_draft` job has been failing since April 2, 2026 with:

```
Unsupported file extension: .ansible/team-devtools. Supported extensions are: json, yml, yaml
```

This started when renovate bumped `release-drafter` from v6 to v7 in [team-devtools#443](https://github.com/ansible/team-devtools/pull/443). In v7, the `_extends` syntax changed — it now requires the full file path, not just the repo name.

## Fix

```yaml
# v6 (old)
_extends: ansible/team-devtools

# v7 (new)
_extends: ansible/team-devtools:.github/release-drafter.yml
```

## Reference

From the [release-drafter v7 breaking changes](https://github.com/release-drafter/release-drafter/pull/1475):

> the `_extends` config-keyword now uses the same syntax as the `config-name:` input

Full syntax documented in [Configuration Loading](https://github.com/release-drafter/release-drafter/blob/master/docs/configuration-loading.md).

## Test plan

- [ ] `push.yml` → `update_release_draft` job passes after merge