### PR TITLE
fix: update noqa comments to new ruff syntax

### DIFF
--- a/src/ansible_compat/__init__.py
+++ b/src/ansible_compat/__init__.py
@@ -1,5 +1,5 @@
 """ansible_compat package."""
-# ruff: noqa: RUF067
+# ruff:file-ignore[RUF067]
 
 from importlib.metadata import PackageNotFoundError, version
 

--- a/src/ansible_compat/config.py
+++ b/src/ansible_compat/config.py
@@ -7,7 +7,7 @@ import ast
 import copy
 import os
 import re
-import subprocess  # noqa: S404
+import subprocess  # ruff:ignore[S404]
 from collections import UserDict
 from typing import TYPE_CHECKING, ClassVar, Literal
 
@@ -62,7 +62,7 @@ def ansible_version(version: str = "") -> Version:
 
 class AnsibleConfig(
     UserDict[str, object],
-):  # pylint: disable=too-many-ancestors # noqa: DOC605
+):  # pylint: disable=too-many-ancestors # ruff:ignore[DOC605]
     """Interface to query Ansible configuration.
 
     This should allow user to access everything provided by `ansible-config dump` without having to parse the data himself.
@@ -475,7 +475,7 @@ class AnsibleConfig(
     galaxy_role_skeleton_ignore: ClassVar[list[str]] = ["^.git$", "^.*/.git_keep$"]
     galaxy_server: str = "https://galaxy.ansible.com"
     galaxy_server_list: str | None = None
-    galaxy_token_path: str = "~/.ansible/galaxy_token"  # noqa: S105
+    galaxy_token_path: str = "~/.ansible/galaxy_token"  # ruff:ignore[S105]
     host_key_checking: bool = True
     host_pattern_mismatch: Literal["warning", "error", "ignore"] = "warning"
     inject_facts_as_vars: bool = True

--- a/src/ansible_compat/loaders.py
+++ b/src/ansible_compat/loaders.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from pathlib import Path
 
 
-def yaml_from_file(path: Path) -> Any:  # noqa: ANN401
+def yaml_from_file(path: Path) -> Any:  # ruff:ignore[ANN401]
     """Return a loaded YAML file."""
     with path.open(encoding="utf-8") as content:
         return yaml.load(content, Loader=yaml.SafeLoader)

--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -12,7 +12,7 @@ import os
 import re
 import shutil
 import site
-import subprocess  # noqa: S404
+import subprocess  # ruff:ignore[S404]
 import sys
 import warnings
 from collections import OrderedDict
@@ -108,7 +108,7 @@ class Plugins:  # pylint: disable=too-many-instance-attributes
     keyword: dict[str, str] = field(init=False)
 
     @no_type_check
-    def __getattribute__(self, attr: str):  # noqa: ANN204
+    def __getattribute__(self, attr: str):  # ruff:ignore[ANN204]
         """Get attribute.
 
         Raises:
@@ -262,13 +262,13 @@ class Runtime:
         from ansible.utils.display import Display
 
         # pylint: disable=unused-argument
-        def warning(  # noqa: DOC103
-            self: Display,  # noqa: ARG001
+        def warning(  # ruff:ignore[DOC103]
+            self: Display,  # ruff:ignore[ARG001]
             msg: str,
-            formatted: bool = False,  # noqa: ARG001,FBT001,FBT002
+            formatted: bool = False,  # ruff:ignore[ARG001,FBT001,FBT002]
             *,
-            help_text: str | None = None,  # noqa: ARG001
-            obj: Any = None,  # noqa: ARG001,ANN401
+            help_text: str | None = None,  # ruff:ignore[ARG001]
+            obj: Any = None,  # ruff:ignore[ARG001,ANN401]
         ) -> None:  # pragma: no cover
             """Override ansible.utils.display.Display.warning to avoid printing warnings."""
             warnings.warn(
@@ -281,7 +281,7 @@ class Runtime:
         # Monkey patch ansible warning in order to use warnings module.
         Display.warning = warning
 
-    def initialize_logger(self, level: int = 0) -> None:  # noqa: PLR6301
+    def initialize_logger(self, level: int = 0) -> None:  # ruff:ignore[PLR6301]
         """Set up the global logging level based on the verbosity number."""
         verbosity_map = {
             -2: logging.CRITICAL,
@@ -429,7 +429,7 @@ class Runtime:
             # ruff: enable[PLC2701]
 
             with contextlib.suppress(Exception):
-                _AnsibleCollectionFinder()._remove()  # pylint: disable=protected-access  # noqa: SLF001
+                _AnsibleCollectionFinder()._remove()  # pylint: disable=protected-access  # ruff:ignore[SLF001]
 
             init_plugin_loader(col_paths)
             Runtime.initialized = True
@@ -1096,7 +1096,7 @@ class Runtime:
 
 
 def _validate_requirements_yaml(
-    reqs_yaml: Any,  # noqa: ANN401
+    reqs_yaml: Any,  # ruff:ignore[ANN401]
     requirement: Path,
 ) -> None:
     """Validate that *reqs_yaml* is a well-formed Ansible requirements structure.

--- a/src/ansible_compat/schema.py
+++ b/src/ansible_compat/schema.py
@@ -90,7 +90,7 @@ def validate(
     try:
         if not isinstance(schema, Mapping):
             msg = "Invalid schema, must be a mapping"
-            raise jsonschema.SchemaError(msg)  # noqa: TRY301
+            raise jsonschema.SchemaError(msg)  # ruff:ignore[TRY301]
         validator = validator_for(schema)
         validator.check_schema(schema)
     except jsonschema.SchemaError as exc:


### PR DESCRIPTION
Ruff 0.15.21 deprecated the old `# noqa: RULE` syntax in favor of `# ruff:ignore[RULE]` for inline and `# ruff:file-ignore[RULE]` for file-level suppressions. Update all 15 occurrences. This unblocks the pending pep621 dependency update PR #597 which is failing lint because of this.