### PR TITLE
fix: skip collection modules in ANSIBLE_LIBRARY

### DIFF
--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -970,13 +970,19 @@ class Runtime:
             raise RuntimeError(msg) from exc
 
         alterations_list: list[tuple[list[str], str, bool]] = [
-            (
-                library_paths,
-                str((self.project_dir / "plugins" / "modules").absolute()),
-                True,
-            ),
             (roles_path, str((self.project_dir / "roles").absolute()), True),
         ]
+        # Collection modules must stay namespaced; do not expose as legacy
+        # ANSIBLE_LIBRARY (see https://github.com/ansible/ansible-compat/issues/605).
+        if not (self.project_dir / GALAXY_YML).exists():
+            alterations_list.insert(
+                0,
+                (
+                    library_paths,
+                    str((self.project_dir / "plugins" / "modules").absolute()),
+                    True,
+                ),
+            )
 
         alterations_list.extend(
             (

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -1133,6 +1133,42 @@ def test_prepare_ansible_paths_uses_absolute_library_path(
     )
 
 
+def test_prepare_ansible_paths_skips_library_for_collections(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Collection plugins/modules must not be added to ANSIBLE_LIBRARY.
+
+    Regression test for https://github.com/ansible/ansible-compat/issues/605:
+    exposing a collection's modules as legacy short names can shadow builtins
+    (e.g. ansible.legacy.stat resolving to the collection's stat.py stub).
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    project_dir = tmp_path / "example_collection"
+    project_dir.mkdir()
+    (project_dir / "galaxy.yml").write_text(
+        "namespace: example\nname: test\nversion: 1.0.0\n",
+        encoding="utf-8",
+    )
+    modules_dir = project_dir / "plugins" / "modules"
+    modules_dir.mkdir(parents=True)
+    (modules_dir / "stat.py").write_text(
+        '"""Documentation-only module stub."""\n',
+        encoding="utf-8",
+    )
+
+    runtime = Runtime(project_dir=project_dir, isolated=False)
+    runtime._prepare_ansible_paths()
+
+    library_env = runtime.environ.get("ANSIBLE_LIBRARY", "")
+    project_library_path = str(modules_dir.absolute())
+    assert project_library_path not in library_env.split(":"), (
+        f"Collection modules path '{project_library_path}' must not appear in "
+        f"ANSIBLE_LIBRARY, got: {library_env}"
+    )
+
+
 def test_prepare_ansible_paths_survives_cwd_change(tmp_path: pathlib.Path) -> None:
     """Verify that resolved paths remain valid even after changing CWD.
 


### PR DESCRIPTION
## Summary
- Skip injecting `project_dir/plugins/modules` into `ANSIBLE_LIBRARY` when the project has a `galaxy.yml` (collection projects).
- Keeps absolute library/roles path injection for non-collection projects (no regression of #583).
- Adds a regression test so collection module stubs (e.g. `stat.py`) cannot shadow `ansible.legacy` builtins.

Fixes #605

## Test plan
- [x] `uv run pytest test/test_runtime.py -k prepare_ansible_paths`
- [ ] Confirm Molecule collection CI (e.g. `community.openwrt`) no longer resolves `ansible.legacy.stat` to the collection stub after this release lands
- [ ] Spot-check a non-collection project still gets `plugins/modules` on `ANSIBLE_LIBRARY`