### PR TITLE
fix(CI): strip tox-local Ansible env vars in smoke tests

### DIFF
--- a/tools/smoke.py
+++ b/tools/smoke.py
@@ -21,6 +21,19 @@ tmp_path = Path(tempfile.gettempdir()) / f"ansible-compat-smoke-{checksum}"
 
 logger.info("Using %s temporary directory...", tmp_path)
 
+# Tox sets ANSIBLE_HOME={envdir}/.ansible for ansible-compat test envs.
+# Downstream projects (especially ansible-lint via has_custom_ansible_env)
+# treat that as a user override and disable project isolation, which breaks
+# their cache_dir tests. Strip tox-local Ansible path overrides before
+# running those suites.
+for var in (
+    "ANSIBLE_HOME",
+    "ANSIBLE_LIBRARY",
+    "ANSIBLE_ROLES_PATH",
+    "ANSIBLE_COLLECTIONS_PATH",
+):
+    os.environ.pop(var, None)
+
 for project in ("molecule", "ansible-lint"):
     logger.info("Running tests for %s", project)
     project_dir = tmp_path / project


### PR DESCRIPTION
## Summary

- Fix failing `tox -e smoke` on main caused by tox-injected `ANSIBLE_HOME` leaking into downstream ansible-lint tests
- Clear tox-local Ansible path env vars in `tools/smoke.py` before cloning and running molecule/ansible-lint suites
- Restores expected project-isolated cache dir behavior in ansible-lint's `test_initialize_options_cache_dir_creation[online]`, which unblocks the `check` job (alls-green gate)

## Problem

Scheduled tox runs on main have been failing in `smoke` and `check`:
- https://github.com/ansible/ansible-compat/actions/runs/30865593538
- https://github.com/ansible/ansible-compat/actions/runs/31059506442

The smoke job runs ansible-lint's test suite with the current ansible-compat code. One test fails in online mode:

`test/test_main.py::test_initialize_options_cache_dir_creation[online]`

Expected cache dir: `<tmp>/project/.ansible`  
Actual cache dir: `.tox/smoke/.ansible`

Root cause:

1. ansible-compat tox sets `ANSIBLE_HOME={envdir}/.ansible` for its own test envs (`pyproject.toml`).
2. Recent ansible-lint uses `has_custom_ansible_env()` and disables project isolation when `ANSIBLE_HOME` (or related vars) is set.
3. In online mode, ansible-lint then resolves the cache dir to `ANSIBLE_HOME` instead of `project_dir/.ansible`.
4. The offline parametrization still passes because it explicitly expects `ANSIBLE_HOME`.
5. The `check` job fails only because `alls-green` sees `smoke` as failed.

This is not a bug in ansible-compat's `get_cache_dir()` logic; reordering `VIRTUAL_ENV` vs `project_dir` does not change this failure path.

## Solution

Before running downstream smoke suites, unset tox-local Ansible path overrides:

- `ANSIBLE_HOME`
- `ANSIBLE_LIBRARY`
- `ANSIBLE_ROLES_PATH`
- `ANSIBLE_COLLECTIONS_PATH`

That lets ansible-lint run with normal project isolation during its online cache-dir test, while ansible-compat's own tox env configuration remains unchanged.

## Test plan

- [ ] Push branch and confirm `tox / smoke` passes on CI
- [ ] Confirm `tox / check` passes once smoke is green
- [ ] Optionally run locally: `tox -e smoke`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved downstream test execution by ensuring tests run with a clean environment.
  * Prevented local configuration variables from affecting cache and project-isolation test results.

* **User Impact**
  * No changes to application functionality or end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->